### PR TITLE
Remove `require_all` dependency and use of present? method

### DIFF
--- a/lib/nearest_time_zone.rb
+++ b/lib/nearest_time_zone.rb
@@ -1,21 +1,22 @@
-require "csv"
-require "kdtree"
+require 'csv'
+require 'kdtree'
 
-require "require_all"
-require_rel "./nearest_time_zone"
+require_relative 'nearest_time_zone/city.rb'
+require_relative 'nearest_time_zone/dump.rb'
+require_relative 'nearest_time_zone/railtie.rb'
+require_relative 'nearest_time_zone/time_zone.rb'
+require_relative 'nearest_time_zone/version.rb'
 
+# Top level module
 module NearestTimeZone
-
   def self.to(latitude, longitude)
     nearest_city = City.nearest(latitude, longitude)
-    if nearest_city.present?
-      nearest_city.time_zone.name
-    end
+    nearest_city && nearest_city.time_zone.name
   end
 
   def self.dump
     Dump.dump
-    puts "dumped!"
+    puts 'dumped!'
   end
 end
 

--- a/nearest_time_zone.gemspec
+++ b/nearest_time_zone.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 
-  spec.add_dependency "require_all"
   spec.add_dependency "kdtree"
 end


### PR DESCRIPTION
Removing require_all dependency because there is now some confusion as to how it is licensed.  (See jarmo/require_all#14 for details.)  Also removing the use of `present?` since that method is not in core Ruby.  Finally, converted some double-quotes to single-quotes to appease rubocop.