### PR TITLE
Remove call to present? and clean up rubocop warnings

### DIFF
--- a/lib/nearest_time_zone.rb
+++ b/lib/nearest_time_zone.rb
@@ -1,21 +1,20 @@
-require "csv"
-require "kdtree"
+require 'pathname'
+require 'csv'
+require 'kdtree'
 
-require "require_all"
-require_rel "./nearest_time_zone"
+require 'require_all'
+require_rel './nearest_time_zone'
 
+# Base Module
 module NearestTimeZone
-
   def self.to(latitude, longitude)
     nearest_city = City.nearest(latitude, longitude)
-    if nearest_city.present?
-      nearest_city.time_zone.name
-    end
+    nearest_city && nearest_city.time_zone.name
   end
 
   def self.dump
     Dump.dump
-    puts "dumped!"
+    puts 'dumped!'
   end
 end
 

--- a/lib/nearest_time_zone/city.rb
+++ b/lib/nearest_time_zone/city.rb
@@ -1,15 +1,20 @@
 module NearestTimeZone
+  # City class
   class City
+    DATA_DIR = Pathname.new(__FILE__).dirname + '../../data'.freeze
 
     attr_accessor :id, :latitude, :longitude, :time_zone_id
 
     def initialize(id, latitude, longitude, time_zone_id)
-      self.id, self.latitude, self.longitude, self.time_zone_id = id, latitude, longitude, time_zone_id
+      self.id           = id
+      self.latitude     = latitude
+      self.longitude    = longitude
+      self.time_zone_id = time_zone_id
     end
 
     def self.kdtree
       @kdtree ||= build_kdtree
-    end    
+    end
 
     def id=(value)
       @id = value.to_i
@@ -39,28 +44,23 @@ module NearestTimeZone
       TimeZone.find(time_zone_id)
     end
 
-  private
-
-    def self.load_all
-      begin
-        Marshal.load(File.read(File.expand_path("../../../data/cities.dump", __FILE__)))
-      rescue
-        cities = CSV.open(File.expand_path("../../../data/cities.txt", __FILE__))
-        Hash[
-          cities.collect do |city|
-            [city[0].to_i, NearestTimeZone::City.new(*(0..3).collect { |n| city[n] })]
-          end
-        ]
-      end
+    private_class_method def self.load_all
+      Marshal.load(File.read(DATA_DIR + 'cities.txt'))
+    rescue
+      cities = CSV.open(DATA_DIR + 'cities.txt')
+      Hash[
+        cities.collect do |city|
+          [city[0].to_i, City.new(*(0..3).collect { |n| city[n] })]
+        end
+      ]
     end
 
-    def self.build_kdtree
-      begin
-        File.open(File.expand_path("../../../data/kdtree.dump", __FILE__)) { |f| Kdtree.new(f) }
-      rescue
-        Kdtree.new all.collect { |id, city| [city.latitude, city.longitude, city.id] }
+    private_class_method def self.build_kdtree
+      File.open(DATA_DIR + 'kdtree.dump') { |f| Kdtree.new(f) }
+    rescue
+      Kdtree.new all.collect do |_id, city|
+        [city.latitude, city.longitude, city.id]
       end
     end
-
   end
 end

--- a/lib/nearest_time_zone/dump.rb
+++ b/lib/nearest_time_zone/dump.rb
@@ -1,21 +1,18 @@
 module NearestTimeZone
+  # Dump utility
   class Dump
+    DATA_DIR = Pathname.new(__FILE__).dirname + '../../data'.freeze
 
     def self.dump
-      data_folder = "../../../data"
-      
-      File.open(File.expand_path("#{data_folder}/cities.dump", __FILE__),"wb") do |f|
+      File.open(DATA_DIR + 'cities.dump', 'wb') do |f|
         f.write Marshal.dump(City.all)
       end
-
-      File.open(File.expand_path("#{data_folder}/time_zones.dump", __FILE__),"wb") do |f|
+      File.open(DATA_DIR + 'time_zones.dump', 'wb') do |f|
         f.write Marshal.dump(TimeZone.all)
       end
-
-      File.open(File.expand_path("#{data_folder}/kdtree.dump", __FILE__),"wb") do |f|
+      File.open(DATA_DIR + 'kdtree.dump', 'wb') do |f|
         City.kdtree.persist(f)
       end
     end
-
   end
 end

--- a/lib/nearest_time_zone/railtie.rb
+++ b/lib/nearest_time_zone/railtie.rb
@@ -1,13 +1,14 @@
 if defined?(Rails)
 
   module NearestTimeZone
+    # railtie class
     class Engine < Rails::Railtie
       railtie_name :nearest_time_zone
 
       rake_tasks do
-        load "tasks/nearest_time_zone_tasks.rake"
+        load 'tasks/nearest_time_zone_tasks.rake'
       end
     end
   end
-  
+
 end

--- a/lib/nearest_time_zone/time_zone.rb
+++ b/lib/nearest_time_zone/time_zone.rb
@@ -1,10 +1,13 @@
 module NearestTimeZone
+  # timezone class
   class TimeZone
+    DATA_DIR = Pathname.new(__FILE__).dirname + '../../data'.freeze
 
     attr_accessor :id, :name
 
     def initialize(id, name)
-      self.id, self.name = id, name
+      self.id = id
+      self.name = name
     end
 
     def id=(value)
@@ -19,20 +22,15 @@ module NearestTimeZone
       all[id.to_i]
     end
 
-  private
-
-    def self.load_all
-      begin
-        Marshal.load(File.read(File.expand_path("../../../data/time_zones.dump", __FILE__)))
-      rescue
-        time_zones = CSV.open(File.expand_path("../../../data/time_zones.txt", __FILE__))
-        Hash[
-          time_zones.collect do |time_zone|
-            [time_zone[0].to_i, NearestTimeZone::TimeZone.new(time_zone[0].to_i, time_zone[1])]
-          end
-        ]
-      end
+    private_class_method def self.load_all
+      Marshal.load(File.read(DATA_DIR + 'time_zones.dump'))
+    rescue
+      time_zones = CSV.open(DATA_DIR + 'time_zones.txt')
+      Hash[
+        time_zones.collect do |time_zone|
+          [time_zone[0].to_i, TimeZone.new(time_zone[0].to_i, time_zone[1])]
+        end
+      ]
     end
-
   end
 end

--- a/lib/nearest_time_zone/version.rb
+++ b/lib/nearest_time_zone/version.rb
@@ -1,3 +1,3 @@
 module NearestTimeZone
-  VERSION = "0.0.4"
+  VERSION = '0.0.4'.freeze
 end

--- a/nearest_time_zone.gemspec
+++ b/nearest_time_zone.gemspec
@@ -1,27 +1,30 @@
 # coding: utf-8
+require 'English'
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'nearest_time_zone/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "nearest_time_zone"
+  spec.name          = 'nearest_time_zone'
   spec.version       = NearestTimeZone::VERSION
-  spec.authors       = ["Sean Devine"]
-  spec.email         = ["barelyknown@icloud.com"]
-  spec.description   = %q{Quickly find the name of a time zone for a latitude and longitude without relying on a web service.}
-  spec.summary       = %q{Quickly find the name of a time zone for a latitude and longitude without relying on a web service.}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Sean Devine']
+  spec.email         = ['barelyknown@icloud.com']
+  spec.description   = 'Quickly find the name of a time zone for a latitude' \
+                       ' and longitude without relying on a web service.'
+  spec.summary       = spec.summary
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($RS)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 
-  spec.add_dependency "require_all"
-  spec.add_dependency "kdtree"
+  spec.add_dependency 'require_all'
+  spec.add_dependency 'kdtree'
 end


### PR DESCRIPTION
This fixes the call to the unsupported `present?` method and reformats/refactors to clean up the warnings from rubocop.  The latter involved:

- replacing double quotes with single quotes in string literals that do not require interpolation
- removing ineffective `private` declarations and replacing them with `private_class_method`
- adding class-level comments
- DRY-ing out the file path manipulation code using the built-in Pathname class
- removing parallel assignment from constructors
- removing unneeded `begin`/`end` blocks
- removing unneeded module qualification